### PR TITLE
Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         ]
     },
     "require": {
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/notifications": "^8.0|^9.0|^10.0|^11.0|^12.0"
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/notifications": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
## Summary
- Add Laravel 13 (`illuminate/support` and `illuminate/notifications` `^13.0`) to the package's version constraints in `composer.json`.
- Existing support for Laravel 8–12 is preserved (constraints are additive).
